### PR TITLE
Fix joining channels

### DIFF
--- a/lib/Net/IRC/Handlers/Default.pm
+++ b/lib/Net/IRC/Handlers/Default.pm
@@ -37,6 +37,7 @@ class Net::IRC::Handlers::Default {
 	#Autojoin method. Handy.
 	multi method connected($ev) {
 		$ev.conn.sendln("JOIN $_") for $ev.state<autojoin>.list;
+        1;
 	}
 
 


### PR DESCRIPTION
by forcing sink context on the for loop.
Otherwise it only works when called in sink context.
