### PR TITLE
CommandHandler.pm: Fix compiler regex warning.

### DIFF
--- a/lib/Net/IRC/CommandHandler.pm
+++ b/lib/Net/IRC/CommandHandler.pm
@@ -17,7 +17,7 @@ role Net::IRC::CommandHandler {
 			$ev.what ~~ token {
 				# Intro
 				^
-				[ \s* $<nick>=("$ev.state()<nick>") [ <[':' ',']> | \s ] ]? \s*
+				[ \s* $<nick>=("$ev.state()<nick>") [ ':' | ',' | \s ] ]? \s*
 				[ $<prefix>=("$handler.prefix()") \s* ]?
 
 				# Actual command (and optional params)


### PR DESCRIPTION
When doing a `panda install` I get the following warning:
```
PERL6LIB=/home/jengelen/perl6/net-irc-bot/blib/lib:/home/jengelen/perl6/net-irc-bot/lib: perl6 --target=mbc --output=blib/lib/Net/IRC/CommandHandler.pm.moarvm lib/Net/IRC/CommandHandler.pm
Potential difficulties:
    Repeated character (') unexpectedly found in character class
    at lib/Net/IRC/CommandHandler.pm:20
    ------>     [ \s* $<nick>=("$ev.state()<nick>") [ <⏏[':' ',']> | \s ] ]? \s*
```
It seems that the latest Rakudo does not interpret the line as was originally meant by the author. This pull request fixes that, and the warning.