### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Net/IRC/Modules/ACME.pm
+++ b/lib/Net/IRC/Modules/ACME.pm
@@ -1,7 +1,7 @@
 use v6;
 use Net::IRC::CommandHandler;
 
-module Net::IRC::Modules::ACME;
+unit module Net::IRC::Modules::ACME;
 
 #= Enjoy delicious bot snacks
 class Net::IRC::Modules::ACME::Botsnack does Net::IRC::CommandHandler {

--- a/lib/Net/IRC/Modules/Autoident.pm
+++ b/lib/Net/IRC/Modules/Autoident.pm
@@ -1,5 +1,5 @@
 use v6;
-module Net::IRC::Modules::Autoident;
+unit module Net::IRC::Modules::Autoident;
 
 #= Automatically identify with Nickserv
 class Net::IRC::Modules::Autoident {

--- a/lib/Net/IRC/Parser.pm
+++ b/lib/Net/IRC/Parser.pm
@@ -1,6 +1,6 @@
 use v6;
 
-module Net::IRC::Parser;
+unit module Net::IRC::Parser;
 grammar RawEvent {
 	token TOP {
 		^ 

--- a/lib/Net/IRC/TextUtil.pm
+++ b/lib/Net/IRC/TextUtil.pm
@@ -1,6 +1,6 @@
 use v6;
 
-module Net::IRC::TextUtil;
+unit module Net::IRC::TextUtil;
 
 sub _s($num, $plural = 's', $singular = '') is export {
 	$num == 1 ?? $singular !! $plural;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.